### PR TITLE
Add question types and bootstrap UI

### DIFF
--- a/myproject/__init__.py
+++ b/myproject/__init__.py
@@ -38,9 +38,17 @@ def add_question(form_id):
     form = models.Form.query.get_or_404(form_id)
     if request.method == 'POST':
         text = request.form.get('text')
+        q_type = request.form.get('question_type', 'text')
+        options = request.form.get('options')
         if text:
-            question = models.Question(text=text, form_id=form.id)
+            question = models.Question(text=text, form_id=form.id, question_type=q_type)
             db.session.add(question)
+            db.session.commit()
+            if q_type == 'multiple' and options:
+                for opt in options.split(','):
+                    opt_text = opt.strip()
+                    if opt_text:
+                        db.session.add(models.Option(question_id=question.id, text=opt_text))
             db.session.commit()
             return redirect(url_for('add_question', form_id=form.id))
     return render_template('add_question.html', form=form)

--- a/myproject/models.py
+++ b/myproject/models.py
@@ -14,15 +14,29 @@ class Form(db.Model):
 
 class Question(db.Model):
     __tablename__ = 'questions'
-    
-    id = db.Column(db.Integer , primary_key=True)
-    text = db.Column(db.String(200) , nullable=False)
+
+    id = db.Column(db.Integer, primary_key=True)
+    text = db.Column(db.String(200), nullable=False)
+    question_type = db.Column(db.String(20), nullable=False, default='text')
     form_id = db.Column(db.Integer, db.ForeignKey('forms.id'), nullable=False)
     answers = db.relationship('Answer', backref='question', lazy='dynamic')
+    options = db.relationship('Option', backref='question', lazy='dynamic')
 
-    def __init__(self, text, form_id):
+    def __init__(self, text, form_id, question_type='text'):
         self.text = text
         self.form_id = form_id
+        self.question_type = question_type
+
+class Option(db.Model):
+    __tablename__ = 'options'
+
+    id = db.Column(db.Integer, primary_key=True)
+    question_id = db.Column(db.Integer, db.ForeignKey('questions.id'), nullable=False)
+    text = db.Column(db.String(200), nullable=False)
+
+    def __init__(self, question_id, text):
+        self.question_id = question_id
+        self.text = text
 
 class Answer(db.Model):
     __tablename__ = 'answers'

--- a/myproject/templates/add_question.html
+++ b/myproject/templates/add_question.html
@@ -1,10 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Add Question to {{ form.title }}</h1>
-<form method="post">
-  <label>Question Text</label>
-  <input type="text" name="text" required>
-  <button type="submit">Add Question</button>
+<h1 class="mb-4">Add Question to {{ form.title }}</h1>
+<form method="post" class="mb-3">
+  <div class="mb-3">
+    <label class="form-label">Question Text</label>
+    <input class="form-control" type="text" name="text" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Type</label>
+    <select class="form-select" name="question_type">
+      <option value="text">Text</option>
+      <option value="multiple">Multiple Choice</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Options (comma separated for multiple choice)</label>
+    <input class="form-control" type="text" name="options">
+  </div>
+  <button class="btn btn-primary" type="submit">Add Question</button>
 </form>
-<a href="{{ url_for('fill_form', form_id=form.id) }}">Done</a>
+<a class="btn btn-secondary" href="{{ url_for('fill_form', form_id=form.id) }}">Done</a>
 {% endblock %}

--- a/myproject/templates/base.html
+++ b/myproject/templates/base.html
@@ -2,8 +2,11 @@
 <html>
 <head>
     <title>Simple Forms App</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body>
-    {% block content %}{% endblock %}
+<body class="bg-light">
+    <div class="container py-4">
+        {% block content %}{% endblock %}
+    </div>
 </body>
 </html>

--- a/myproject/templates/create_form.html
+++ b/myproject/templates/create_form.html
@@ -1,9 +1,11 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Create New Form</h1>
-<form method="post">
-  <label>Title</label>
-  <input type="text" name="title" required>
-  <button type="submit">Create</button>
+<h1 class="mb-4">Create New Form</h1>
+<form method="post" class="mb-3">
+  <div class="mb-3">
+    <label class="form-label">Title</label>
+    <input class="form-control" type="text" name="title" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Create</button>
 </form>
 {% endblock %}

--- a/myproject/templates/fill_form.html
+++ b/myproject/templates/fill_form.html
@@ -1,11 +1,22 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>{{ form.title }}</h1>
-<form method="post">
+<h1 class="mb-4">{{ form.title }}</h1>
+<form method="post" class="mb-3">
 {% for question in form.questions %}
-  <label>{{ question.text }}</label><br>
-  <input type="text" name="q_{{ question.id }}" required><br><br>
+  <div class="mb-3">
+    <label class="form-label">{{ question.text }}</label>
+    {% if question.question_type == 'multiple' %}
+      {% for opt in question.options %}
+        <div class="form-check">
+          <input class="form-check-input" type="radio" name="q_{{ question.id }}" value="{{ opt.text }}" required>
+          <label class="form-check-label">{{ opt.text }}</label>
+        </div>
+      {% endfor %}
+    {% else %}
+      <input class="form-control" type="text" name="q_{{ question.id }}" required>
+    {% endif %}
+  </div>
 {% endfor %}
-  <button type="submit">Submit</button>
+  <button class="btn btn-primary" type="submit">Submit</button>
 </form>
 {% endblock %}

--- a/myproject/templates/index.html
+++ b/myproject/templates/index.html
@@ -1,10 +1,17 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Forms</h1>
-<ul>
+<h1 class="mb-4">Forms</h1>
+<ul class="list-group mb-3">
 {% for form in forms %}
-  <li><a href="{{ url_for('fill_form', form_id=form.id) }}">{{ form.title }}</a> - <a href="{{ url_for('add_question', form_id=form.id) }}">Add Questions</a> - <a href="{{ url_for('form_results', form_id=form.id) }}">Results</a></li>
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span>{{ form.title }}</span>
+    <span>
+      <a class="btn btn-sm btn-primary" href="{{ url_for('fill_form', form_id=form.id) }}">Fill</a>
+      <a class="btn btn-sm btn-secondary" href="{{ url_for('add_question', form_id=form.id) }}">Add Questions</a>
+      <a class="btn btn-sm btn-info" href="{{ url_for('form_results', form_id=form.id) }}">Results</a>
+    </span>
+  </li>
 {% endfor %}
 </ul>
-<a href="{{ url_for('create_form') }}">Create New Form</a>
+<a class="btn btn-success" href="{{ url_for('create_form') }}">Create New Form</a>
 {% endblock %}

--- a/myproject/templates/results.html
+++ b/myproject/templates/results.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>{{ form.title }} - Results</h1>
+<h1 class="mb-4">{{ form.title }} - Results</h1>
 {% for question in form.questions %}
-  <h3>{{ question.text }}</h3>
-  <ul>
+  <h5>{{ question.text }}</h5>
+  <ul class="list-group mb-3">
   {% for answer in question.answers %}
-    <li>{{ answer.answer_text }}</li>
+    <li class="list-group-item">{{ answer.answer_text }}</li>
   {% endfor %}
   </ul>
 {% endfor %}
-<a href="{{ url_for('index') }}">Back</a>
+<a class="btn btn-secondary" href="{{ url_for('index') }}">Back</a>
 {% endblock %}

--- a/myproject/templates/thank_you.html
+++ b/myproject/templates/thank_you.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<p>Thank you for submitting the form.</p>
-<a href="{{ url_for('index') }}">Back to home</a>
+<p class="fs-4">Thank you for submitting the form.</p>
+<a class="btn btn-primary" href="{{ url_for('index') }}">Back to home</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support different question types with new `Option` model
- style templates using Bootstrap
- add form fields for question type and options

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ea879b86c8328a2d95d30ab5218d5