### PR TITLE
Fix chart size on results page

### DIFF
--- a/myproject/templates/results.html
+++ b/myproject/templates/results.html
@@ -6,7 +6,7 @@
 {% for question in form.questions %}
   <h5 class="mt-4">{{ question.text }}</h5>
   {% if question.question_type == 'multiple' %}
-    <canvas id="chart-{{ question.id }}" height="200" width="300" style="max-width: 100%; height: auto;"></canvas>
+    <canvas id="chart-{{ question.id }}" height="200" width="200" style="width: 100%; max-width: 300px; height: auto;"></canvas>
     <script>
       var ctx = document.getElementById('chart-{{ question.id }}').getContext('2d');
       new Chart(ctx, {


### PR DESCRIPTION
## Summary
- shrink the results page chart canvas so charts aren't overly large

## Testing
- `pytest -q`
- `flask db migrate -m "no schema change"`
- `flask db upgrade`


------
https://chatgpt.com/codex/tasks/task_e_68712ba293f48328952f8ff55b978196